### PR TITLE
Fix empty string function in lookup example

### DIFF
--- a/1-en/api-for-developers.md
+++ b/1-en/api-for-developers.md
@@ -710,7 +710,7 @@ Layout file for showing page type:
 Code for breaking up a URL:
 
 ``` php
-if (!is_empty_string($url)) {
+if (!is_string_empty($url)) {
     list($scheme, $address, $base) = $this->yellow->lookup->getUrlInformation($staticUrl);
     echo "Found scheme:$scheme address:$address base:$base\n";
 }

--- a/2-de/api-for-developers.md
+++ b/2-de/api-for-developers.md
@@ -710,7 +710,7 @@ Layoutdatei um den Seitentyp anzuzeigen:
 Code um eine URL in Bestandteile zu zerlegen:
 
 ``` php
-if (!is_empty_string($url)) {
+if (!is_string_empty($url)) {
     list($scheme, $address, $base) = $this->yellow->lookup->getUrlInformation($staticUrl);
     echo "Found scheme:$scheme address:$address base:$base\n";
 }

--- a/3-sv/api-for-developers.md
+++ b/3-sv/api-for-developers.md
@@ -711,7 +711,7 @@ Layoutfil för att visa sidtyp:
 Kod för att dela upp en URL:
 
 ``` php
-if (!is_empty_string($url)) {
+if (!is_string_empty($url)) {
     list($scheme, $address, $base) = $this->yellow->lookup->getUrlInformation($staticUrl);
     echo "Found scheme:$scheme address:$address base:$base\n";
 }


### PR DESCRIPTION
This quick one fixes the example code for breaking up a URL under Yellow lookup examples. Hope this is useful 🙂