### PR TITLE
Updated documentation for YellowLanguage functions

### DIFF
--- a/1-en/api-for-developers.md
+++ b/1-en/api-for-developers.md
@@ -402,13 +402,13 @@ Return language setting
 `language->getTextHtml($key, $language = ""): string`  
 Return language setting, HTML encoded
 
-`page->getDateStandard($text, $language = ""): string`  
+`language->getDateStandard($text, $language = ""): string`  
 Return text as [language specific date](how-to-change-the-system#language-settings), convert to one of the standard formats
 
-`page->getDateRelative($timestamp, $format, $daysLimit, $language = ""): string`  
+`language->getDateRelative($timestamp, $format, $daysLimit, $language = ""): string`  
 Return Unix time as [date](https://www.php.net/manual/en/function.date.php), relative to today
 
-`page->getDateFormatted($timestamp, $format, $language = ""): string`  
+`language->getDateFormatted($timestamp, $format, $language = ""): string`  
 Return Unix time as [date](https://www.php.net/manual/en/function.date.php)
 
 `language->getSettings($filterStart = "", $filterEnd = "", $language = ""): array`  

--- a/2-de/api-for-developers.md
+++ b/2-de/api-for-developers.md
@@ -403,13 +403,13 @@ Hole eine Spracheinstellung
 `language->getTextHtml($key, $language = ""): string`  
 Hole eine Spracheinstellung, HTML-kodiert
 
-`page->getDateStandard($text, $language = ""): string`  
+`language->getDateStandard($text, $language = ""): string`  
 Hole einen Text als [sprachspezifisches Datum](how-to-change-the-system#spracheinstellungen), in eines der Standardformate konvertieren
 
-`page->getDateRelative($timestamp, $format, $daysLimit, $language = ""): string`  
+`language->getDateRelative($timestamp, $format, $daysLimit, $language = ""): string`  
 Hole eine Unix-Zeit als [Datum](https://www.php.net/manual/de/function.date.php), relativ zu heute
 
-`page->getDateFormatted($timestamp, $format, $language = ""): string`  
+`language->getDateFormatted($timestamp, $format, $language = ""): string`  
 Hole eine Unix-Zeit als [Datum](https://www.php.net/manual/de/function.date.php)
 
 `language->getSettings($filterStart = "", $filterEnd = "", $language = ""): array`  

--- a/3-sv/api-for-developers.md
+++ b/3-sv/api-for-developers.md
@@ -403,13 +403,13 @@ Returnera språkinställning
 `language->getTextHtml($key, $language = ""): string`  
 Returnera språkinställning, HTML-kodad
 
-`page->getDateStandard($text, $language = ""): string`  
+`language->getDateStandard($text, $language = ""): string`  
 Returnera text som [språkspecifikt datum](how-to-change-the-system#språkinställningar), konvertera till ett av standardformaten
 
-`page->getDateRelative($timestamp, $format, $daysLimit, $language = ""): string`  
+`language->getDateRelative($timestamp, $format, $daysLimit, $language = ""): string`  
 Returnera Unix-tid som [datum](https://www.php.net/manual/en/function.date.php), i förhållande till idag
 
-`page->getDateFormatted($timestamp, $format, $language = ""): string`  
+`language->getDateFormatted($timestamp, $format, $language = ""): string`  
 Returnera Unix-tid som [datum](https://www.php.net/manual/en/function.date.php)
 
 `language->getSettings($filterStart = "", $filterEnd = "", $language = ""): array`  


### PR DESCRIPTION
With this pull request I suggest to put the correct class for the GetDate functions under Yellow Language in the API documentation, because `getDateFormatted`, `getDateRelative` and `getDateStandard` are also used for a slightly different purpose under Yellow Page. This could lead to confusion about the purpose for the language functions. 

I hope this is useful and I didn't get confused by the documentation myself. 🙂